### PR TITLE
Fix chat history save error and update sql

### DIFF
--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -195,6 +195,7 @@ export async function saveChat(chat: Chat, userId: string = 'anonymous') {
       user_id: user.id,
       title,
       messages: chat.messages || [],
+      is_pinned: false, // Default to false for new chats
       share_path: chat.sharePath || null,
       created_at: chat.createdAt || new Date(),
       updated_at: new Date()
@@ -210,6 +211,13 @@ export async function saveChat(chat: Chat, userId: string = 'anonymous') {
 
     if (error) {
       console.error('Error saving chat:', error)
+      console.error('Supabase error details:', {
+        message: error.message,
+        details: error.details,
+        hint: error.hint,
+        code: error.code
+      })
+      console.error('Chat data being saved:', JSON.stringify(chatData, null, 2))
       throw new Error('Failed to save chat')
     }
 

--- a/lib/streaming/handle-stream-finish.ts
+++ b/lib/streaming/handle-stream-finish.ts
@@ -90,6 +90,12 @@ export async function handleStreamFinish({
       userId
     ).catch(error => {
       console.error('Failed to save chat:', error)
+      console.error('Chat data:', JSON.stringify({
+        id: chatId,
+        userId,
+        messagesCount: generatedMessages.length,
+        savedChatId: savedChat.id
+      }, null, 2))
       throw new Error('Failed to save chat history')
     })
   } catch (error) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix chat history saving by including the `is_pinned` field and enhancing error logging.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `saveChat` function was failing to save chat history because the `is_pinned` column, expected by the database, was not being provided in the `chatData` object. This PR adds the default `is_pinned: false` and improves error messages for easier debugging of chat saving failures.

---

[Open in Web](https://cursor.com/agents?id=bc-733a890e-6c36-4c01-92c8-9ae2ecef3ded) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-733a890e-6c36-4c01-92c8-9ae2ecef3ded) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)